### PR TITLE
유저 인증 기반 추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://winereview-api.vercel.app

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,9 +1,11 @@
 import { Outlet } from 'react-router-dom';
 import { Header } from '@src/components/header/Header';
+import { AuthInitializer } from './AuthInitializer';
 
 export default function App() {
   return (
     <>
+      <AuthInitializer />
       <Header />
       <main>
         <Outlet />

--- a/src/app/AuthInitializer.tsx
+++ b/src/app/AuthInitializer.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { axiosInstance } from '@src/shared/apis/axios';
+
+import { useAuthStore } from '@src/domain/user/stores/authStore';
+import type { UserMeResponse } from '@src/domain/user/Interface/UserMeResponse';
+import { mapUserMeResponseToUser } from '@src/domain/user/mapper/mapper';
+
+export function AuthInitializer() {
+  const login = useAuthStore((state) => state.login);
+  const logout = useAuthStore((state) => state.logout);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function initializeAuth() {
+      try {
+        const response = await axiosInstance.get<UserMeResponse>('/users/me');
+
+        if (!mounted) return;
+
+        const user = mapUserMeResponseToUser(response.data);
+        login(user);
+      } catch (error) {
+        console.error(error);
+        if (!mounted) return;
+        logout();
+      }
+    }
+
+    initializeAuth();
+
+    return () => {
+      mounted = false;
+    };
+  }, [login, logout]);
+
+  return null;
+}

--- a/src/domain/user/Interface/User.ts
+++ b/src/domain/user/Interface/User.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: number;
+  nickname: string;
+  profileImage: string;
+}

--- a/src/domain/user/Interface/UserMeResponse.ts
+++ b/src/domain/user/Interface/UserMeResponse.ts
@@ -1,0 +1,8 @@
+export interface UserMeResponse {
+  id: number;
+  nickname: string;
+  image: string;
+  teamId: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/domain/user/mapper/mapper.ts
+++ b/src/domain/user/mapper/mapper.ts
@@ -1,0 +1,12 @@
+// src/domain/user/mapper.ts
+
+import type { User } from '../Interface/User';
+import type { UserMeResponse } from '../Interface/UserMeResponse';
+
+export function mapUserMeResponseToUser(dto: UserMeResponse): User {
+  return {
+    id: dto.id,
+    nickname: dto.nickname,
+    profileImage: dto.image,
+  };
+}

--- a/src/domain/user/stores/authStore.ts
+++ b/src/domain/user/stores/authStore.ts
@@ -1,10 +1,5 @@
 import { create } from 'zustand';
-
-interface User {
-  id: number;
-  name: string;
-  profileImage: string;
-}
+import type { User } from '../Interface/User';
 
 interface AuthState {
   user: User | null;

--- a/src/shared/apis/axios.ts
+++ b/src/shared/apis/axios.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { API_BASE_URL } from './config';
+import { TEAM_ID } from './team';
 
 export const axiosInstance = axios.create({
-  baseURL: API_BASE_URL,
+  baseURL: `${API_BASE_URL}/${TEAM_ID}`,
   timeout: 10_000,
   withCredentials: true,
   headers: {

--- a/src/shared/apis/team.ts
+++ b/src/shared/apis/team.ts
@@ -1,0 +1,1 @@
+export const TEAM_ID = '20-2';


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

사용자 인증 기능 구현을 위한 기초 도메인 구조를 추가했습니다.

서버의 `/users/me` 응답을 프론트엔드에서 일관되게 사용하기 위해  
User 도메인 모델, DTO(UserMeResponse), DTO → 도메인 매퍼를 분리해 구성했고,  
이를 전역으로 관리하기 위한 인증 스토어(authStore)를 함께 도입했습니다.
해당 작업은 이후 로그인 기능 구현을 위한 사전 작업입니다.


<!---- Resolves: #14  -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 기능 추가 (feature)
- [ ] 버그 수정 (fix)
- [ ] 스타일 수정 (style)
- [ ] 코드 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 추가 / 수정 (test)
- [ ] 빌드 / 패키지 설정 변경 (build)
- [ ] 파일 / 폴더 구조 변경 (chore)
- [ ] 파일 혹은 폴더 삭제 (chore)
